### PR TITLE
4329b1 ip4 iOS 5.1.1

### DIFF
--- a/patcher/bcm-patcher.py
+++ b/patcher/bcm-patcher.py
@@ -146,6 +146,7 @@ if __name__ == "__main__":
 
     hash_str = sha1(firmware_data).hexdigest()
     diff_fname = hash_str + '.diff'
+    print '\firmware hash: ', diff_fname
     check_file(diff_fname, 'diff file not found (unsupported firmware?)')
    
     crcoffset = crc_offsets[hash_str]


### PR DESCRIPTION
added 
print '\firmware hash: ', diff_fname

visual view of the calculated hash

this are links to the firmware files

4329b1 ip4 iOS 5.1.1

bachelor-wapi.bin   sha1:bf344c8f6c821a912b5372a6bfffcb92b8b17072
http://db.tt/f9HincI9

bachelor.bin    sha1:19ce78843d7caad1abfee0fc5807e9dd275158f5
http://db.tt/QhpcE1Ic
